### PR TITLE
Electron dependency leads builder to include electron twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
     "eslint-plugin-import": "^2.7.0",
     "mocha": "^3.5.0",
     "sinon": "^3.1.0"
-  },
-  "dependencies": {
-    "electron": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "sinon": "^3.1.0"
   },
   "dependencies": {
-    "electron": "^1.7.5"
+    "electron": "*"
   }
 }


### PR DESCRIPTION
See https://github.com/gyselroth/balloon-client-desktop/issues/58