### PR TITLE
Better positioning when it overflows the screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ positioner.calculate(windowBounds, trayBounds, alignment);
 The value can be one of `left`, `center` or `right`, default is `center`.
 
 * `alignmet.y` alignment on y axis relative to tray icon when tray bar is left or right.
-The value can be one of `up`, `middle` or `down`, default is `down`.
+The value can be one of `up`, `center` or `down`, default is `down`.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ npm install --save electron-traywindow-positioner
 ## Usage
 
 ```
-const positioner = require('electron-traywindow-positioner');
+const positioner = require('electron-traywindow-positioner')
 
-positioner.position(trayWindow, trayBounds);
+positioner.position(trayWindow, trayBounds)
 ```
 
 * `trayWindow` must be an instance of a [`BrowserWindow`](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#wingetbounds).
@@ -27,9 +27,9 @@ positioner.position(trayWindow, trayBounds);
 ### Only calculate the postion without positioning the window
 
 ```
-const positioner = require('electron-traywindow-positioner');
+const positioner = require('electron-traywindow-positioner')
 
-positioner.calculate(windowBounds, trayBounds);
+positioner.calculate(windowBounds, trayBounds)
 
 ```
 
@@ -41,15 +41,15 @@ positioner.calculate(windowBounds, trayBounds);
 ### Custom alignment
 
 ```
-const alignment = {x: 'left', y: 'up'};
+const alignment = {x: 'left', y: 'up'}
 
-const positioner = require('electron-traywindow-positioner');
+const positioner = require('electron-traywindow-positioner')
 
-positioner.position(trayWindow, trayBounds, alignment);
+positioner.position(trayWindow, trayBounds, alignment, edge)
 
 // or
 
-positioner.calculate(windowBounds, trayBounds, alignment);
+positioner.calculate(windowBounds, trayBounds, alignment, edge)
 ```
 
 * `alignmet.x` alignment on x axis relative to tray icon when tray bar is top or bottom.
@@ -57,3 +57,6 @@ The value can be one of `left`, `center` or `right`, default is `center`.
 
 * `alignmet.y` alignment on y axis relative to tray icon when tray bar is left or right.
 The value can be one of `up`, `center` or `down`, default is `down`.
+
+* `edge` tells positioner to align the window to the edge of the screen when it overlaps
+the screen. By default it is `false` so it just just aligns to the opposite side.

--- a/index.js
+++ b/index.js
@@ -93,20 +93,12 @@ const positioner = {
     const display = this._getDisplay();
     let x;
 
-    function alignLeft() {
-      return trayBounds.x + trayBounds.width - windowBounds.width;
-    }
-
-    function alignRight() {
-      return trayBounds.x;
-    }
-
     switch (align) {
       case 'right':
-        x = alignRight();
+        x = trayBounds.x;
         break;
       case 'left':
-        x = alignLeft();
+        x = trayBounds.x + trayBounds.width - windowBounds.width;
         break;
       case 'center':
       default:
@@ -114,11 +106,11 @@ const positioner = {
     }
 
     if (x + windowBounds.width > display.bounds.width && align !== 'left') {
-      // if window would overlap on right side align it left
-      x = alignLeft();
+      // if window would overlap on right side align it to the end of the screen
+      x = display.bounds.width - windowBounds.width
     } else if (x < 0 && align !== 'right') {
       // if window would overlap on the left side align it right
-      x = alignRight();
+      x = 0;
     }
 
     return x;
@@ -136,30 +128,22 @@ const positioner = {
     const display = this._getDisplay();
     let y;
 
-    function alignUp() {
-      return trayBounds.y + trayBounds.height - windowBounds.height;
-    }
-
-    function alignDown() {
-      return trayBounds.y;
-    }
-
     switch (align) {
       case 'up':
-        y = alignUp();
+        y =  trayBounds.y + trayBounds.height - windowBounds.height;
         break;
       case 'center':
         y = Math.round((trayBounds.y + (trayBounds.height / 2)) - (windowBounds.height / 2));
         break;
       case 'down':
       default:
-        y = alignDown();
+        y = trayBounds.y;
     }
 
     if (y + windowBounds.height > display.bounds.height && align !== 'up') {
-      y = alignUp();
+      y = display.bounds.height - windowBounds.height
     } else if (y < 0 && align !== 'down') {
-      y = alignDown();
+      y = 0;
     }
 
     return y;

--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
     "eslint-plugin-import": "^2.7.0",
     "mocha": "^3.5.0",
     "sinon": "^3.1.0"
-  },
-  "dependencies": {
-    "electron": "^1.7.5"
   }
 }


### PR DESCRIPTION
- Fixes the instruction on the README which says to put 'middle' when it's 'center'
- When overflowing the screen by the right side, just align it so the window end is touching the end of the screen
- The same for the left side, and for y.