### PR TITLE
_getDisplay() should return primary display

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,13 +207,13 @@ const positioner = {
   },
 
   /**
-   * Get the display nearest the current cursor position
+   * Get the main display 
    *
-   * @return {Electron.Display} - the display closest to the current cursor position
+   * @return {Electron.Display} - returns the primary display
    */
   _getDisplay() {
     const screen = this._getScreen();
-    return screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+    return screen.getPrimaryDisplay();
   },
 };
 


### PR DESCRIPTION
This avoids issues in Windows when working with multiple monitors. If  you start the app in a desktop and then move your mouse accidentally to the other desktop windows appears out of place. Also it makes sense to work with the primary display as it contains the taskbar app icons.